### PR TITLE
Switch to multithreaded generation

### DIFF
--- a/rgen/Cargo.lock
+++ b/rgen/Cargo.lock
@@ -2302,6 +2302,7 @@ name = "rgen-world"
 version = "0.1.0"
 dependencies = [
  "lru",
+ "parking_lot",
  "rgen-base",
 ]
 

--- a/rgen/Cargo.lock
+++ b/rgen/Cargo.lock
@@ -808,6 +808,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -995,6 +1014,12 @@ checksum = "803bfcb1ad294dd7f106e26ac9199730d16051496ddb66b10fdb6529eb43df58"
 dependencies = [
  "egui",
 ]
+
+[[package]]
+name = "either"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "emath"
@@ -2189,6 +2214,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42a9830a0e1b9fb145ebb365b8bc4ccd75f290f98c0247deafbbe2c75cefb544"
 
 [[package]]
+name = "rayon"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2303,6 +2348,7 @@ version = "0.1.0"
 dependencies = [
  "lru",
  "parking_lot",
+ "rayon",
  "rgen-base",
 ]
 

--- a/rgen/Cargo.lock
+++ b/rgen/Cargo.lock
@@ -2346,6 +2346,7 @@ dependencies = [
 name = "rgen-world"
 version = "0.1.0"
 dependencies = [
+ "crossbeam-channel",
  "lru",
  "parking_lot",
  "rayon",

--- a/rgen/rgen-jni/Cargo.toml
+++ b/rgen/rgen-jni/Cargo.toml
@@ -19,3 +19,6 @@ jni = "0.21.1"
 [features]
 # Links to obfuscated names. Used for release builds.
 obf-names = []
+
+[[bench]]
+name = "chunk"

--- a/rgen/rgen-jni/benches/chunk.rs
+++ b/rgen/rgen-jni/benches/chunk.rs
@@ -1,0 +1,64 @@
+#![feature(test)]
+
+extern crate test;
+
+use std::sync::Arc;
+
+use rgen_base::{Biomes, Blocks, Chunk, ChunkPos, Pos};
+use rgen_world::{CachedWorld, Context, Generator, PartialWorld};
+use test::Bencher;
+
+#[bench]
+fn bench_chunk(b: &mut Bencher) {
+  let world = Arc::new(CachedWorld::new());
+  let context = Arc::new(rgen_world::Context {
+    seed:   1 as u64,
+    blocks: Blocks::test_blocks(),
+    biomes: Biomes::test_blocks(),
+  });
+  let generator =
+    Arc::new(TerrainGenerator::new(&context.blocks, &context.biomes, context.seed as u64));
+  world.spawn_threads(&context, &generator);
+
+  let mut chunk_pos = ChunkPos::new(0, 0);
+
+  b.iter(|| {
+    chunk_pos.x += 1;
+    if chunk_pos.x > 20 {
+      chunk_pos.x = 0;
+      chunk_pos.z += 1;
+    }
+
+    world.generate(&context, generator.as_ref(), chunk_pos, |_| {});
+  });
+}
+
+pub struct TerrainGenerator {
+  pub seed: u64,
+
+  pub biomes: rgen_biome::WorldBiomes,
+}
+
+impl Generator for TerrainGenerator {
+  fn height_at(&self, _: Pos) -> f64 { 0.0 }
+
+  fn generate_biomes(&self, chunk_pos: ChunkPos, biomes: &mut [u8; 256]) {
+    self.biomes.generate_ids(self.seed, chunk_pos, biomes);
+  }
+
+  fn generate_base(&self, ctx: &Context, chunk: &mut Chunk, chunk_pos: ChunkPos) {
+    self.biomes.generate_base(self.seed, ctx, chunk, chunk_pos);
+  }
+
+  fn decorate(&self, ctx: &Context, world: &mut PartialWorld, chunk_pos: ChunkPos) {
+    self.biomes.decorate(&ctx.blocks, self.seed, world, chunk_pos);
+
+    world.set(chunk_pos.min_block_pos() + Pos::new(0, 6, 0), ctx.blocks.dirt.block);
+  }
+}
+
+impl TerrainGenerator {
+  pub fn new(blocks: &Blocks, biome_ids: &rgen_base::Biomes, seed: u64) -> TerrainGenerator {
+    TerrainGenerator { seed, biomes: rgen_biome::WorldBiomes::new(blocks, biome_ids) }
+  }
+}

--- a/rgen/rgen-jni/src/api.rs
+++ b/rgen/rgen-jni/src/api.rs
@@ -135,9 +135,9 @@ pub extern "system" fn Java_net_macmv_rgen_rust_RustGenerator_build_1chunk(
     let chunk_ctx =
       ChunkContext { chunk_pos: ChunkPos::new(chunk_x, chunk_z), blocks: &ctx.context.blocks };
 
-    let mut world = ctx.world.lock().unwrap();
-    let chunk = world.generate(&ctx.context, &ctx.generator, chunk_ctx.chunk_pos);
-    env.set_char_array_region(data, 0, chunk.data()).unwrap();
+    ctx.world.generate(&ctx.context, &ctx.generator, chunk_ctx.chunk_pos, |chunk| {
+      env.set_char_array_region(data, 0, chunk.data()).unwrap();
+    });
   });
 }
 

--- a/rgen/rgen-jni/src/api.rs
+++ b/rgen/rgen-jni/src/api.rs
@@ -135,7 +135,7 @@ pub extern "system" fn Java_net_macmv_rgen_rust_RustGenerator_build_1chunk(
     let chunk_ctx =
       ChunkContext { chunk_pos: ChunkPos::new(chunk_x, chunk_z), blocks: &ctx.context.blocks };
 
-    ctx.world.generate(&ctx.context, &ctx.generator, chunk_ctx.chunk_pos, |chunk| {
+    ctx.world.generate(&ctx.context, ctx.generator.as_ref(), chunk_ctx.chunk_pos, |chunk| {
       env.set_char_array_region(data, 0, chunk.data()).unwrap();
     });
   });

--- a/rgen/rgen-jni/src/ctx.rs
+++ b/rgen/rgen-jni/src/ctx.rs
@@ -1,13 +1,13 @@
-use std::sync::{Mutex, RwLock};
+use std::sync::RwLock;
 
 use rgen_base::{Biomes, Blocks};
-use rgen_world::PartialWorld;
+use rgen_world::CachedWorld;
 
 use crate::generator::TerrainGenerator;
 
 pub struct Context {
   pub generator: TerrainGenerator,
-  pub world:     Mutex<PartialWorld>,
+  pub world:     CachedWorld,
 
   pub context: rgen_world::Context,
 }
@@ -20,7 +20,7 @@ impl Context {
 
     let ctx = Context {
       generator,
-      world: Mutex::new(PartialWorld::new()),
+      world: CachedWorld::new(),
       context: rgen_world::Context { seed: seed as u64, blocks, biomes },
     };
 

--- a/rgen/rgen-viewer/src/terrain.rs
+++ b/rgen/rgen-viewer/src/terrain.rs
@@ -1,7 +1,7 @@
 // FIXME: This really shouldn't live here.
 
 use rgen_base::{Blocks, Chunk, ChunkPos, Pos};
-use rgen_world::{Context, Generator, PartialWorld};
+use rgen_world::{Context, Generator, PartialDecoratedWorld};
 
 pub struct TerrainGenerator {
   pub seed: u64,
@@ -26,7 +26,7 @@ impl Generator for TerrainGenerator {
     self.biomes.generate_base(self.seed, ctx, chunk, chunk_pos);
   }
 
-  fn decorate(&self, ctx: &Context, world: &mut PartialWorld, chunk_pos: ChunkPos) {
+  fn decorate(&self, ctx: &Context, world: &mut PartialDecoratedWorld, chunk_pos: ChunkPos) {
     self.biomes.decorate(&ctx.blocks, self.seed, world, chunk_pos);
 
     world.set(chunk_pos.min_block_pos() + Pos::new(0, 6, 0), ctx.blocks.dirt.block);

--- a/rgen/rgen-viewer/src/terrain.rs
+++ b/rgen/rgen-viewer/src/terrain.rs
@@ -1,7 +1,7 @@
 // FIXME: This really shouldn't live here.
 
 use rgen_base::{Blocks, Chunk, ChunkPos, Pos};
-use rgen_world::{Context, Generator, PartialDecoratedWorld};
+use rgen_world::{Context, Generator, PartialWorld};
 
 pub struct TerrainGenerator {
   pub seed: u64,
@@ -26,7 +26,7 @@ impl Generator for TerrainGenerator {
     self.biomes.generate_base(self.seed, ctx, chunk, chunk_pos);
   }
 
-  fn decorate(&self, ctx: &Context, world: &mut PartialDecoratedWorld, chunk_pos: ChunkPos) {
+  fn decorate(&self, ctx: &Context, world: &mut PartialWorld, chunk_pos: ChunkPos) {
     self.biomes.decorate(&ctx.blocks, self.seed, world, chunk_pos);
 
     world.set(chunk_pos.min_block_pos() + Pos::new(0, 6, 0), ctx.blocks.dirt.block);

--- a/rgen/rgen-world/Cargo.toml
+++ b/rgen/rgen-world/Cargo.toml
@@ -5,4 +5,5 @@ edition = "2021"
 
 [dependencies]
 lru = "0.12.3"
+parking_lot = "0.12.1"
 rgen-base.workspace = true

--- a/rgen/rgen-world/Cargo.toml
+++ b/rgen/rgen-world/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2021"
 [dependencies]
 lru = "0.12.3"
 parking_lot = "0.12.1"
+rayon = "1.9.0"
 rgen-base.workspace = true

--- a/rgen/rgen-world/Cargo.toml
+++ b/rgen/rgen-world/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+crossbeam-channel = "0.5.12"
 lru = "0.12.3"
 parking_lot = "0.12.1"
 rayon = "1.9.0"

--- a/rgen/rgen-world/src/block.rs
+++ b/rgen/rgen-world/src/block.rs
@@ -4,8 +4,10 @@ use crate::PartialWorld;
 use rgen_base::{Block, BlockState, Chunk, ChunkPos, Pos};
 
 impl PartialWorld {
-  fn chunk(&mut self, pos: ChunkPos) -> Option<&Chunk> { self.chunks.get(&pos).map(|c| &c.chunk) }
-  fn chunk_mut(&mut self, chunk_pos: ChunkPos) -> Option<&mut Chunk> {
+  pub(crate) fn chunk(&mut self, pos: ChunkPos) -> Option<&Chunk> {
+    self.chunks.get(&pos).map(|c| &c.chunk)
+  }
+  pub(crate) fn chunk_mut(&mut self, chunk_pos: ChunkPos) -> Option<&mut Chunk> {
     self.chunks.get_mut(&chunk_pos).map(|c| &mut c.chunk)
   }
 

--- a/rgen/rgen-world/src/gc.rs
+++ b/rgen/rgen-world/src/gc.rs
@@ -1,0 +1,71 @@
+use rgen_base::ChunkPos;
+
+use crate::{CachedWorld, Stage};
+
+impl CachedWorld {
+  pub fn gc(&self) {
+    let mut chunks = self.chunks.lock();
+    let mut base_chunks = self.base_chunks.lock();
+    let mut requester_chunks = self.requester.chunks.write();
+
+    let chunks = &mut chunks.chunks;
+    let mut gc = vec![];
+
+    for (&pos, chunk) in chunks.iter() {
+      match chunk.stage {
+        // Base chunks: These can be GC'ed if none of the 8 surrounding chunks are decorated.
+        Stage::Base => {
+          let mut can_gc = true;
+          'outer: for rel_x in -1..=1 {
+            for rel_z in -1..=1 {
+              if rel_x == 0 && rel_z == 0 {
+                continue;
+              }
+              let pos = pos + ChunkPos::new(rel_x, rel_z);
+
+              if chunks.get(&pos).map(|c| c.stage == Stage::Decorated).unwrap_or(false) {
+                can_gc = false;
+                break 'outer;
+              }
+            }
+          }
+
+          if can_gc {
+            gc.push(pos);
+          }
+        }
+
+        // Decorated chunks: These can be GC'ed if none of the 8 surrounding chunks are neighbor
+        // decorated.
+        Stage::Decorated => {
+          let mut can_gc = true;
+          'outer: for rel_x in -1..=1 {
+            for rel_z in -1..=1 {
+              if rel_x == 0 && rel_z == 0 {
+                continue;
+              }
+              let pos = pos + ChunkPos::new(rel_x, rel_z);
+
+              if chunks.get(&pos).map(|c| c.stage == Stage::NeighborDecorated).unwrap_or(false) {
+                can_gc = false;
+                break 'outer;
+              }
+            }
+          }
+
+          if can_gc {
+            gc.push(pos);
+          }
+        }
+
+        Stage::NeighborDecorated => gc.push(pos),
+      }
+    }
+
+    for pos in gc {
+      chunks.remove(&pos);
+      base_chunks.remove(&pos);
+      requester_chunks.remove(&pos);
+    }
+  }
+}

--- a/rgen/rgen-world/src/lib.rs
+++ b/rgen/rgen-world/src/lib.rs
@@ -130,8 +130,13 @@ impl CachedWorld {
     pos: ChunkPos,
     f: impl FnOnce(&Chunk) -> R,
   ) -> R {
-    for x in -RADIUS * 2..=RADIUS * 2 {
-      for z in -RADIUS * 2..=RADIUS * 2 {
+    // The minimum radius required to generate a neighbor decorated chunk is `RADIUS
+    // + 2`. However, this leads to very low parallelism when generating a region of
+    // chunks next to each other. Increasing this by 1 leads to much better real
+    // world performance (~15x), where chunks are generated next to each other
+    // often. Increasing this any more only has negligible speed improvements.
+    for x in -RADIUS * 3..=RADIUS * 3 {
+      for z in -RADIUS * 3..=RADIUS * 3 {
         self.request(pos + ChunkPos::new(x, z), Stage::Base);
       }
     }

--- a/rgen/rgen-world/src/lib.rs
+++ b/rgen/rgen-world/src/lib.rs
@@ -144,7 +144,7 @@ impl CachedWorld {
     self.request(pos, Stage::NeighborDecorated);
 
     loop {
-      std::thread::sleep(std::time::Duration::from_millis(10));
+      std::thread::sleep(std::time::Duration::from_micros(100));
 
       let w = self.chunks.lock();
       match w.chunks.get(&pos) {

--- a/rgen/rgen-world/src/lib.rs
+++ b/rgen/rgen-world/src/lib.rs
@@ -267,3 +267,29 @@ impl Requester {
     }
   }
 }
+
+impl fmt::Display for PartialWorld {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    write!(f, "PartialWorld {{")?;
+
+    let min_x = self.chunks.keys().map(|p| p.x).min().unwrap_or(0);
+    let max_x = self.chunks.keys().map(|p| p.x).max().unwrap_or(0);
+    let min_z = self.chunks.keys().map(|p| p.z).min().unwrap_or(0);
+    let max_z = self.chunks.keys().map(|p| p.z).max().unwrap_or(0);
+
+    for z in min_z..=max_z {
+      write!(f, "\n  ")?;
+      for x in min_x..=max_x {
+        let pos = ChunkPos::new(x, z);
+        let stage = match self.chunks.get(&pos).map(|c| c.stage) {
+          Some(Stage::Base) => "B",
+          Some(Stage::Decorated) => "D",
+          Some(Stage::NeighborDecorated) => "N",
+          None => " ",
+        };
+        write!(f, "{} ", stage)?;
+      }
+    }
+    write!(f, "\n}}")
+  }
+}

--- a/rgen/rgen-world/src/lib.rs
+++ b/rgen/rgen-world/src/lib.rs
@@ -155,26 +155,22 @@ impl CachedWorld {
       }
     }
 
-    for i in 0.. {
+    let mut i = 0;
+    loop {
       // If the GC runs while we're waiting, the chunk might not get generated. This
       // is here to make sure it always gets generated.
       if i % 10 == 0 {
         self.request(pos, Stage::NeighborDecorated);
       }
+      i += 1;
 
       std::thread::sleep(std::time::Duration::from_micros(100));
 
       let w = self.chunks.lock();
       match w.chunks.get(&pos) {
-        Some(chunk) if chunk.stage == Stage::NeighborDecorated => break,
+        Some(chunk) if chunk.stage == Stage::NeighborDecorated => break f(&chunk.chunk),
         _ => continue,
       }
-    }
-
-    {
-      let mut w = self.chunks.lock();
-      let chunk = w.chunk(pos).unwrap();
-      f(&chunk)
     }
   }
 


### PR DESCRIPTION
Brrr

This makes chunks take around 1ms to generate on average, compared to around ~14ms per chunk on `main`.

This also fixes the split trees on chunk borders, as it replaces the LRU with a garbage collection algorithm which cleans up chunks in the correct order. This results in no more broken decorations, but an increase in memory usage.
