### PR TITLE
Add statically defined property types

### DIFF
--- a/rgen/rgen-base/src/biome.rs
+++ b/rgen/rgen-base/src/biome.rs
@@ -1,0 +1,89 @@
+macro_rules! ids {
+  (
+    $enum_name:ident, $macro_name:ident
+    $default_id:ident => $default_namespace:ident:$default_name:ident,
+    $($id:ident => $namespace:ident:$name:ident,)*
+  ) => {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub enum $enum_name {
+      $default_id,
+      $($id,)*
+    }
+
+    #[macro_export]
+    macro_rules! $macro_name {
+      // block_kind![air]
+      ($default_name) => { $crate::$enum_name::$default_id };
+      // block_kind![minecraft:air]
+      ($default_namespace:$default_name) => { $crate::$enum_name::$default_id };
+      // block_kind![stone] -> block_kind![minecraft:stone]
+      ($block_name:ident) => { $crate::$macro_name![$default_namespace:$block_name] };
+      $(
+        // block_kind![rgen:log]
+        ($namespace:$name) => { $crate::$enum_name::$id };
+      )*
+
+      ($other_namespace:ident:$other:ident) => {
+        compile_error!(concat!("unknown block ", stringify!($other_namespace), ":", stringify!($other)))
+      };
+    }
+
+    impl $enum_name {
+      pub fn name(&self) -> &'static str {
+        match self {
+          $(
+            Self::$id => concat!(stringify!($namespace), ":", stringify!($name)),
+          )*
+          _ => concat!(stringify!($default_namespace), ":", stringify!($default_name)),
+        }
+      }
+
+      pub fn by_name(name: &str) -> Option<Self> {
+        match name {
+          s if s == concat!(stringify!($default_namespace), ":", stringify!($default_name)) => Some(Self::$default_id),
+          $(s if s == concat!(stringify!($namespace), ":", stringify!($name)) => Some(Self::$id),)*
+          _ => None
+        }
+      }
+
+      pub const ALL: &[Self] = &[
+        Self::$default_id,
+        $(Self::$id,)*
+      ];
+    }
+  };
+}
+
+/// A realized biome ID.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(transparent)]
+pub struct BiomeId(pub u8);
+
+impl BiomeId {
+  pub const VOID: BiomeId = BiomeId(127);
+}
+
+#[allow(clippy::derivable_impls)]
+impl Default for Biome {
+  fn default() -> Biome { Biome::Void }
+}
+
+ids! { Biome, biome
+  Void => minecraft:void,
+
+  ColdTaiga => minecraft:taiga_cold,
+  Taiga => minecraft:taiga,
+  ExtremeHills => minecraft:extreme_hills,
+  IcePlains => minecraft:ice_flats,
+  Plains => minecraft:plains,
+  Beaches => minecraft:beaches,
+  RoofedForest => minecraft:roofed_forest,
+  Savanna => minecraft:savanna,
+  Swamp => minecraft:swampland,
+  StoneBeach => minecraft:stone_beach,
+  Jungle => minecraft:jungle,
+  BirchForest => minecraft:birch_forest_hills,
+  River => minecraft:river,
+  Mesa => minecraft:mesa,
+  Desert => minecraft:desert,
+}

--- a/rgen/rgen-base/src/block.rs
+++ b/rgen/rgen-base/src/block.rs
@@ -29,15 +29,6 @@ impl BlockId {
   pub const AIR: BlockId = BlockId(0);
 }
 
-/// A realized biome ID.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[repr(transparent)]
-pub struct BiomeId(pub u8);
-
-impl BiomeId {
-  pub const VOID: BiomeId = BiomeId(127);
-}
-
 /// A block state represents a block with a specific data value (like wool
 /// color).
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -136,11 +127,6 @@ impl BlockState {
   pub fn with_data(&self, data: u8) -> BlockState { self.block.with_data(data) }
 }
 
-#[allow(clippy::derivable_impls)]
-impl Default for Biome {
-  fn default() -> Biome { Biome::Void }
-}
-
 impl PartialEq<BlockKind> for BlockState {
   fn eq(&self, other: &BlockKind) -> bool { self.block == *other }
 }
@@ -192,30 +178,28 @@ macro_rules! block {
   };
 }
 
-// Block Identification Guide
-macro_rules! big {
+macro_rules! blocks {
   (
-    $enum_name:ident, $macro_name:ident
     $default_id:ident => $default_namespace:ident:$default_name:ident,
     $($id:ident => $namespace:ident:$name:ident,)*
   ) => {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub enum $enum_name {
+    pub enum BlockKind {
       $default_id,
       $($id,)*
     }
 
     #[macro_export]
-    macro_rules! $macro_name {
+    macro_rules! block_kind {
       // block_kind![air]
-      ($default_name) => { $crate::$enum_name::$default_id };
+      ($default_name) => { $crate::BlockKind::$default_id };
       // block_kind![minecraft:air]
-      ($default_namespace:$default_name) => { $crate::$enum_name::$default_id };
+      ($default_namespace:$default_name) => { $crate::BlockKind::$default_id };
       // block_kind![stone] -> block_kind![minecraft:stone]
-      ($block_name:ident) => { $crate::$macro_name![$default_namespace:$block_name] };
+      ($block_name:ident) => { $crate::block_kind![$default_namespace:$block_name] };
       $(
         // block_kind![rgen:log]
-        ($namespace:$name) => { $crate::$enum_name::$id };
+        ($namespace:$name) => { $crate::BlockKind::$id };
       )*
 
       ($other_namespace:ident:$other:ident) => {
@@ -223,7 +207,7 @@ macro_rules! big {
       };
     }
 
-    impl $enum_name {
+    impl BlockKind {
       pub fn name(&self) -> &'static str {
         match self {
           $(
@@ -249,7 +233,7 @@ macro_rules! big {
   };
 }
 
-big! { BlockKind, block_kind
+blocks! {
   Air => minecraft:air,
 
   Stone => minecraft:stone,
@@ -309,26 +293,6 @@ big! { BlockKind, block_kind
   RgenCactus => rgen:cactus,
   RgenCactusArm => rgen:cactus_arm,
   RgenBasalt => rgen:basalt,
-}
-
-big! { Biome, biome
-  Void => minecraft:void,
-
-  ColdTaiga => minecraft:taiga_cold,
-  Taiga => minecraft:taiga,
-  ExtremeHills => minecraft:extreme_hills,
-  IcePlains => minecraft:ice_flats,
-  Plains => minecraft:plains,
-  Beaches => minecraft:beaches,
-  RoofedForest => minecraft:roofed_forest,
-  Savanna => minecraft:savanna,
-  Swamp => minecraft:swampland,
-  StoneBeach => minecraft:stone_beach,
-  Jungle => minecraft:jungle,
-  BirchForest => minecraft:birch_forest_hills,
-  River => minecraft:river,
-  Mesa => minecraft:mesa,
-  Desert => minecraft:desert,
 }
 
 #[cfg(test)]

--- a/rgen/rgen-base/src/lib.rs
+++ b/rgen/rgen-base/src/lib.rs
@@ -1,3 +1,4 @@
+mod biome;
 mod block;
 mod chunk;
 mod filter;
@@ -5,9 +6,8 @@ mod iter;
 mod pos;
 mod prop;
 
-pub use block::{
-  Biome, BiomeId, BlockData, BlockId, BlockInfo, BlockKind, BlockState, StateId, StateOrProps,
-};
+pub use biome::{Biome, BiomeId};
+pub use block::{BlockData, BlockId, BlockInfo, BlockKind, BlockState, StateId, StateOrProps};
 pub use chunk::Chunk;
 pub use filter::BlockFilter;
 pub use iter::{BlocksIterExclusive, BlocksIterInclusive};

--- a/rgen/rgen-base/src/prop.rs
+++ b/rgen/rgen-base/src/prop.rs
@@ -63,6 +63,17 @@ impl<const N: usize> From<[&str; N]> for PropType {
   }
 }
 
+impl PropType {
+  pub fn matches(&self, value: &PropValue) -> bool {
+    match (self, value) {
+      (PropType::Bool, PropValue::Bool(_)) => true,
+      (PropType::Int(min, max), PropValue::Int(value)) => min <= value && value <= max,
+      (PropType::Enum(allowed), PropValue::Enum(value)) => allowed.contains(&value.to_string()),
+      _ => false,
+    }
+  }
+}
+
 impl fmt::Debug for PropMap {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     f.debug_map().entries(self.entries()).finish()

--- a/rgen/rgen-base/src/prop.rs
+++ b/rgen/rgen-base/src/prop.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{fmt, ops::RangeInclusive};
 
 #[derive(Clone, Copy, Eq)]
 pub struct PropMap {
@@ -52,6 +52,15 @@ impl From<i32> for PropValue<'_> {
 }
 impl From<&'static str> for PropValue<'_> {
   fn from(value: &'static str) -> Self { PropValue::Enum(value) }
+}
+
+impl From<RangeInclusive<i32>> for PropType {
+  fn from(range: RangeInclusive<i32>) -> Self { PropType::Int(*range.start(), *range.end()) }
+}
+impl<const N: usize> From<[&str; N]> for PropType {
+  fn from(values: [&str; N]) -> Self {
+    PropType::Enum(values.into_iter().map(|s| s.to_string()).collect())
+  }
 }
 
 impl fmt::Debug for PropMap {

--- a/rgen/rgen-jni-impl/src/info.rs
+++ b/rgen/rgen-jni-impl/src/info.rs
@@ -58,6 +58,17 @@ fn read_blocks(info: &mut BlockInfoSupplier, env: &mut JNIEnv) {
         prop_values: call_lookup_prop_values(env, id),
       },
     );
+
+    if let Some(b) = block {
+      let info = &info.info[&BlockId(id as u16)];
+      let expected = b.expected_props();
+      if info.prop_types != expected {
+        panic!(
+          "block {} has unexpected prop types.\njava: {:?}\nrust: {:?}",
+          info.name, info.prop_types, expected
+        );
+      }
+    }
   }
 }
 
@@ -175,7 +186,9 @@ fn call_lookup_prop_types(env: &mut JNIEnv, id: i32) -> HashMap<String, PropType
 
         for i in 0..len {
           let jname = env.get_object_array_element(&array, i).unwrap().into();
-          variants[i as usize] = env.get_string(&jname).unwrap().into();
+          let name: String = env.get_string(&jname).unwrap().into();
+
+          variants[i as usize] = name.to_lowercase();
         }
 
         out.insert(name, PropType::Enum(variants));


### PR DESCRIPTION
Adds all the accepted properties to the `block!` enum, which lets us validate block properties on construction.
